### PR TITLE
[change] ssh_memoの一部訂正

### DIFF
--- a/ssh_memo/Document.md
+++ b/ssh_memo/Document.md
@@ -13,7 +13,7 @@ $ ssh-keygen -p -f ~/.ssh/id_ed25519
 
 ## サーバに公開鍵を設定
 ```bash
-$ ssh-copy-id -i ~/.ssh/id_ed25519 username@serverIP
+$ ssh-copy-id -i ~/.ssh/id_ed25519.pub username@serverIP
 ```
 
 ## サーバ側でのセキュリティ向上


### PR DESCRIPTION
ssh-copy-idコマンドにおいて，公開鍵を指定する部分に誤りがあったため修正
